### PR TITLE
discard incompletely read frames at end

### DIFF
--- a/source/apps/common/input/YUVInput.cpp
+++ b/source/apps/common/input/YUVInput.cpp
@@ -73,6 +73,9 @@ bool YUVInput::readFrame(FrameWithData &frame)
 
     this->input.read((char *) (frame.getData()), frame.getFrameSize());
 
+    if (!this->input)
+        return false;
+
     return true;
 }
 


### PR DESCRIPTION
https://github.com/cd-athena/VCA/issues/29
For YUV frames, we have to check after reading if a complete frame was read. Don't analyze these incomplete frames.