### PR TITLE
input/IInputFile: Change maximum resolution to be 16K DCI

### DIFF
--- a/source/apps/common/input/IInputFile.h
+++ b/source/apps/common/input/IInputFile.h
@@ -24,9 +24,9 @@
 #include <lib/vcaLib.h>
 
 #define MIN_FRAME_WIDTH 64
-#define MAX_FRAME_WIDTH 8192
+#define MAX_FRAME_WIDTH 16384
 #define MIN_FRAME_HEIGHT 64
-#define MAX_FRAME_HEIGHT 4320
+#define MAX_FRAME_HEIGHT 8640
 
 #include <fstream>
 


### PR DESCRIPTION
Basically $(Current Width/Height)*2,

Currently, in the AOM-CTC there are sequences which is >8K either in width/height, so for future-proofing we can relax to setting the maximum width/height to be 16k


Tested locally with https://media.xiph.org/video/aomctc/test_set/f1_still_HiRes/Tencent/lady.y4m

Closes #75 
